### PR TITLE
Upgrade dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-bower-organiser",
   "description": "Organises Bower components according to their types",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "homepage": "https://github.com/mavdi/grunt-bower-organiser",
   "author": {
     "name": "Mehdi Avdi",
@@ -29,9 +29,9 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "grunt-contrib-nodeunit": "~0.1.2",
-    "grunt": "~0.4.0",
-    "bower": "~0.7.0",
+    "grunt-contrib-nodeunit": "~0.2.0",
+    "grunt": "~0.4.1",
+    "bower": "~0.9.2",
     "cli-color" : "0.2.2"
   },
   "keywords": [


### PR DESCRIPTION
the bowerOrganiser task was failing for me on node 0.10.8 because of an error in the depended on bower module. Also, tests weren't passing in this repo because of the same error. Bumping the version on the bower module in package.json fixed it. I also bumped the version on grunt and grunt-contrib-nodeunit.
